### PR TITLE
Print plugin version number at server startup instead of ${plugin.version}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 /target
 /.idea
 *.iml
+
+# jdtls generation
+.classpath
+.factorypath
+.project
+.settings/

--- a/zander-hub/pom.xml
+++ b/zander-hub/pom.xml
@@ -12,6 +12,15 @@
     <artifactId>zander-hub</artifactId>
     <version>1.0</version>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <repositories>
         <!-- PaperMC/WaterFall -->
         <repository>

--- a/zander-hub/src/main/java/org/modularsoft/zander/hub/ZanderHubMain.java
+++ b/zander-hub/src/main/java/org/modularsoft/zander/hub/ZanderHubMain.java
@@ -22,14 +22,14 @@ public class ZanderHubMain extends JavaPlugin {
         plugin = this;
 
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
-//        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", new PluginMessageChannel(this));
+        // this.getServer().getMessenger().registerIncomingPluginChannel(this,
+        // "BungeeCord", new PluginMessageChannel(this));
 
         // Init Message
         TextComponent enabledMessage = Component.empty()
                 .color(NamedTextColor.GREEN)
                 .append(Component.text("\n\nZander Hub has been enabled.\n"))
-//                .append(Component.text("Running Version " + ZanderHubMain.class.getPackage().getImplementationVersion() + "\n"))
-                .append(Component.text("Running Version " + plugin.getDescription().getVersion() + "\n"))
+                .append(Component.text("Running Version " + plugin.getPluginMeta().getVersion() + "\n"))
                 .append(Component.text("GitHub Repository: https://github.com/ModularSoftAU/zander\n"))
                 .append(Component.text("Created by Modular Software\n\n", NamedTextColor.DARK_PURPLE));
         getServer().sendMessage(enabledMessage);
@@ -56,5 +56,6 @@ public class ZanderHubMain extends JavaPlugin {
     }
 
     @Override
-    public void onDisable() {}
+    public void onDisable() {
+    }
 }


### PR DESCRIPTION
![1735683122](https://github.com/user-attachments/assets/77bce90c-701b-4c09-aeb1-1cea88095a90)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude additional Java Development Tools (JDT) related files
	- Modified `pom.xml` to add resource filtering configuration
	- Updated plugin version retrieval method in `ZanderHubMain`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->